### PR TITLE
Speed up date parsing

### DIFF
--- a/aio_georss_client/xml_parser/__init__.py
+++ b/aio_georss_client/xml_parser/__init__.py
@@ -2,6 +2,7 @@
 import logging
 from typing import Dict, Optional
 
+import ciso8601
 import dateparser as dateparser
 import xmltodict
 
@@ -56,6 +57,14 @@ KEYS_FLOAT_LIST = [
 KEYS_INT = [XML_TAG_HEIGHT, XML_TAG_TTL, XML_TAG_WIDTH]
 
 
+def _parse_date(value):
+    """Parse date with ciso8601 or fallback to slower dateparser."""
+    try:
+        return ciso8601.parse_datetime(value)
+    except ValueError:
+        return dateparser.parse(value)
+
+
 class XmlParser:
     """Built-in XML parser."""
 
@@ -70,7 +79,7 @@ class XmlParser:
         """Conduct type conversion for selected keys."""
         try:
             if key in KEYS_DATE and value:
-                return key, dateparser.parse(value)
+                return key, _parse_date(value)
             if key in KEYS_FLOAT and value:
                 return key, float(value)
             if key in KEYS_FLOAT_LIST and value:

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ REQUIRES = [
     "haversine>=1.0.1",
     "xmltodict>=0.12.0",
     "dateparser>=0.7.0",
+    "ciso8601>=2.2.0",
 ]
 
 

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -281,6 +281,12 @@ async def test_update_ok_with_radius_filtering(aresponses, event_loop):
         assert round(abs(entries[0].distance_to_home - 82.0), 1) == 0
         assert round(abs(entries[1].distance_to_home - 77.0), 1) == 0
         assert round(abs(entries[2].distance_to_home - 84.6), 1) == 0
+        assert entries[0].updated == datetime.datetime(2018, 9, 23, 8, 35)
+        assert entries[1].updated == datetime.datetime(2018, 9, 23, 8, 45)
+        assert entries[2].updated == datetime.datetime(2018, 9, 23, 8, 55)
+        assert entries[0].published == datetime.datetime(2018, 9, 23, 8, 30)
+        assert entries[1].published == datetime.datetime(2018, 9, 23, 8, 40)
+        assert entries[2].published == datetime.datetime(2018, 9, 23, 8, 50)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The XML parsing is fast except for the datetime parsing:

https://community.home-assistant.io/t/how-to-install-py-spy-on-a-ha-os-instance-please-instruct/430822/46?u=bdraco

<img width="1209" alt="Screen Shot 2022-06-27 at 10 59 47" src="https://user-images.githubusercontent.com/663432/175983059-07343fdb-dd0f-4fb0-99d8-acbf85e9ba7b.png">
